### PR TITLE
fix README image URLs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present Mahmoud Housam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VizBlend
 
-![PyPI Version](https://img.shields.io/pypi/v/vizblend) ![License](https://img.shields.io/pypi/l/vizblend) ![Build Status](https://github.com/MahmoudHousam/VizBlend/actions/workflows/release.yml/badge.svg) ![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg) ![Downloads](https://img.shields.io/pypi/dm/vizblend) 
+[![PyPI Version](https://img.shields.io/pypi/v/vizblend)](https://pypi.org/project/vizblend/) [![License](https://img.shields.io/pypi/l/vizblend)](https://github.com/MahmoudHousam/VizBlend/blob/master/LICENSE) [![Build Status](https://github.com/MahmoudHousam/VizBlend/actions/workflows/release.yml/badge.svg)](https://github.com/MahmoudHousam/VizBlend/actions) [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://black.readthedocs.io/en/stable/) [![Downloads](https://img.shields.io/pypi/dm/vizblend)](https://pypistats.org/packages/vizblend) 
 
 VizBlend is a Python package that simplifies the process of creating interactive analytical reports by consolidating Plotly figures into a single HTML file. It’s designed to function like a modern PowerPoint presentation but with the power of stunning and interactive data visualizations.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VizBlend
 
-![PyPI Version](https://img.shields.io/pypi/v/vizblend) ![License](https://img.shields.io/pypi/l/vizblend) ![Build Status](https://github.com/MahmoudHousam/VizBlend/actions/workflows/publish.yml/badge.svg) ![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg) ![Downloads](https://img.shields.io/pypi/dm/vizblend) 
+![PyPI Version](https://img.shields.io/pypi/v/vizblend) ![License](https://img.shields.io/pypi/l/vizblend) ![Build Status](https://github.com/MahmoudHousam/VizBlend/actions/workflows/release.yml/badge.svg) ![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg) ![Downloads](https://img.shields.io/pypi/dm/vizblend) 
 
 VizBlend is a Python package that simplifies the process of creating interactive analytical reports by consolidating Plotly figures into a single HTML file. It’s designed to function like a modern PowerPoint presentation but with the power of stunning and interactive data visualizations.
 
@@ -9,7 +9,7 @@ Whether you’re a data analyst, scientist, or developer, VizBlend streamlines t
 # Demo
 Below is a preview of a report generated with VizBlend:
 
-![VizBlend Thumbnail](demo/demo.gif)
+![VizBlend Thumbnail](https://cdn.jsdelivr.net/gh/MahmoudHousam/VizBlend@master/demo/demo.gif)
 
 # Installation
 


### PR DESCRIPTION
This PR fixes README image URLs

- build badge (fix workflow file name)
- demo:
This works on GitHub because it uses a relative URL, however, it does not work on PyPI because it needs an absolute URL.
The PR uses an absolute URL to the same file on [jsDelivr](https://www.jsdelivr.com/) which mirrors GitHub (& npm & others).

![demo](https://cdn.jsdelivr.net/gh/MahmoudHousam/VizBlend@master/demo/demo.gif)

In addition:

- a license file is added
- badge links are added to relevant websites